### PR TITLE
Add quotes to typechain argument for sake of example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ module.exports = {
 
 ```
 "scripts": {
-    "generate": "truffle compile && typechain --target truffle ./build/**/*.json",
+    "generate": "truffle compile && typechain --target truffle './build/**/*.json'",
     "prepare": "yarn generate",
   }
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "truffle": "^4.1.14"
   },
   "scripts": {
-    "generate": "truffle compile && typechain --target truffle ./build/**/*.json",
+    "generate": "truffle compile && typechain --target truffle './build/**/*.json'",
     "prepare": "yarn generate",
     "test": "truffle test && yarn tsc",
     "tsc": "tsc --noEmit"


### PR DESCRIPTION
I copied the scripts from the package json to my Truffle project with multiple contracts. I was trying to figure out why it would only generate bindings for the first (in alphanumeric order) contract and not the rest of the files. I found out in the Typechain project that the quotes to the `glob` argument are important! Adding the quotes here for the sake of example :sunglasses: 